### PR TITLE
Fix win64 download link in header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,7 +12,7 @@
           <a href="https://github.com/Stellarium/stellarium/releases/download/v{{ site.version }}/stellarium-{{ site.version }}-win32.exe">Windows<span>{% include tr.html s="32 bit" %}</span></a>
       </div>
       <div class="download windows">
-          <a href="https://github.com/Stellarium/stellarium/releases/download/v{{ site.version }}/stellarium-{{ site.version }}-win32.exe">Windows<span>{% include tr.html s="64 bit" %}</span></a>
+          <a href="https://github.com/Stellarium/stellarium/releases/download/v{{ site.version }}/stellarium-{{ site.version }}-win64.exe">Windows<span>{% include tr.html s="64 bit" %}</span></a>
       </div>
       <div class="download ubuntu">
           <a href="https://launchpad.net/~stellarium/+archive/stellarium-releases">Ubuntu<span>{% include tr.html s="latest stable release" %}</span></a>


### PR DESCRIPTION
This fixes the download link for 64-bit Windows variant in the header. Currently it is incorrectly pointing to the 32-bit version.