### PR TITLE
Updated URL of landscape Šentvid (Slovenia)

### DIFF
--- a/_landscapes-europe/sentvid.md
+++ b/_landscapes-europe/sentvid.md
@@ -3,7 +3,7 @@ title: Šentvid, Ljubljana, Slovenia
 author: Klemen Blokar, Dejan Kolarič, Ida Kraševec, Andrej Lajovic
 license: CC BY-SA 3.0
 compat: 0.9+
-landscape_url: http://astro.sentvid.org/stellarium/sentvid.zip
-image_url: http://astro.sentvid.org/stellarium/sentvid-thumbnail.png
+landscape_url: http://software.ad-vega.si/stellarium/sentvid.zip
+image_url: http://software.ad-vega.si/stellarium/sentvid-thumbnail.png
 ---
 View from the roof of the observatory of Gymnasium Šentvid, Ljubljana, Slovenia.


### PR DESCRIPTION
The landscape file has been transferred to a different server, so the URL listed on the Stellarium webpage needs to be adjusted.